### PR TITLE
#12 | Use correct package name in the Manual Initialization Readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ See ["tests/rootpath_test.go"](https://github.com/flashlabs/rootpath/blob/main/t
 
 ### Manual Initialization
 
-It is possible to manually chdir to `rootpath` with the `manual.Chdir()` function.
+It is possible to manually chdir to `rootpath` with the `location.Chdir()` function.
 
 All you need to do is to `NOT` `blank import` the `rootpath` package,
-but instead call `manual.Chdir()` when you want to:
+but instead call `location.Chdir()` when you want to:
 
 ```go
 package yours


### PR DESCRIPTION
# What was changed

I've fixed the package name in the `README` `Manual Initialization` section

# Background

It was changed because of a previous refactorization and some leftovers

# How it can be tested

Manually

# Keep in mind that...

n/a
