### PR TITLE
Maintenance | Bump the staticcheck version

### DIFF
--- a/.github/workflows/static-check.yml
+++ b/.github/workflows/static-check.yml
@@ -12,6 +12,6 @@ jobs:
         with:
           fetch-depth: 1
       - name: Static check
-        uses: dominikh/staticcheck-action@v1.3.1
+        uses: dominikh/staticcheck-action@v1
         with:
-          version: "2024.1.1"
+          version: "2025.1.1"


### PR DESCRIPTION
# What was changed

I've updated the `staticcheck` version

# Background

It was changed because of the failing jobs in the CI

# How it can be tested

CI

# Keep in mind that...

n/a
